### PR TITLE
Update elastic_search.py with triple double quote

### DIFF
--- a/app/views/elastic_search.py
+++ b/app/views/elastic_search.py
@@ -8,7 +8,7 @@ client = FlaskElasticsearch()
 
 
 def connect_from_config():
-    "Create connection for `elasticsearch_dsl`"
+    """Create connection for `elasticsearch_dsl`"""
     es_store = Elasticsearch([Config.ELASTICSEARCH_HOST])
     connections.create_connection(hosts=[Config.ELASTICSEARCH_HOST])
 


### PR DESCRIPTION
Issue fixed #5402

Fixes #
In app/views/elastic_search.py'
See line number 11 changed to Triple Double.


#### Short description of what this resolves:
changes single quote string to Triple double string

#### Changes proposed in this pull request:
Changes proposed mentioned above


